### PR TITLE
Remove Step 5 which references new users that were not created in Step 4

### DIFF
--- a/docs/getting-started/try-oauth2.md
+++ b/docs/getting-started/try-oauth2.md
@@ -67,12 +67,6 @@ We can now call one of the API! In particular, we'll try the `/api/userinfo` end
 
 Notice how the interactive documentation automatically added the `Authorization` header with the token!
 
-## 5. See your new user in the admin dashboard
-
-Now that you have a user account in your workspace, you can see it from the admin dashboard! Get back to your admin dashboard and, in the left menu, click on **Users**. This is the list of users in your workspace... And you should see the one you just created!
-
-![Users from admin dashboard](/assets/images/admin-users.png)
-
 ## You're now an OAuth2 master 👏
 
 Congratulations! You've performed a full OAuth2 authentication from A to Z. Those concepts are important to have in mind because they'll be at the core of Fief integration in your app. The key things to remember are:


### PR DESCRIPTION
There is a bit of a conundrum in this section of the documentation.  Step 5 references "new users" that were created in Step 4, but Step 4 does not actually create new Users. 

The alternative I considered suggesting would be to document and demonstrate how to create new users using the OpenAPI documentation with a POST /userinfo (rather than the GET /userinfo) documentation that is currently in Step 4.  But, there is some [confusing documentation and interaction within OpenAPI ](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoRequest) regarding GET /userinfo and POST /userinfo.  When a user selects "GET /userinfo", the "POST /userinfo" OpenAPI accordion also expands as if they are tied together.  So, it doesn't appear to be possible to actually Create a User via the POST /userinfo, not to mention there are no fields in the POST method that would allow that.  

So the best solution I recommend now is to simply remove Step 5 from the documentation.